### PR TITLE
Update StringDictionary.zh-Hans.xaml

### DIFF
--- a/StringDictionary.zh-Hans.xaml
+++ b/StringDictionary.zh-Hans.xaml
@@ -16,7 +16,7 @@
 	<system:String x:Key="Settings.Proxy">代理</system:String>
 
 	<system:String x:Key="Settings.General.RunAtBoot">在 Windows 启动时自动运行</system:String>
-	<system:String x:Key="Settings.General.RunAtConnect">在网络恢复后自动连接虚拟驱动器</system:String>
+	<system:String x:Key="Settings.General.RunAtConnect">在连接虚拟驱动器后打开文件资源管理器</system:String>
 
 	<system:String x:Key="Notice">通知</system:String>
 	<system:String x:Key="AddDrive">添加</system:String>


### PR DESCRIPTION
The original Chinese translation `在网络恢复后自动连接虚拟驱动器` means `Auto connect drives when network is ready`, which is not match with the English one. My translation `在连接虚拟驱动器后打开文件资源管理器` means `Run File Explorer when a drive has connected`.

It appears that the original maintainer for Simplified Chinese just depends on the `x:Key` attributes, and not read the English translation carefully.