### PR TITLE
Fixed up Parts of the German Translations

### DIFF
--- a/StringDictionary.de.xaml
+++ b/StringDictionary.de.xaml
@@ -234,7 +234,7 @@
 	<system:String x:Key="Identity.SignOut.Question2">Möchten Sie sich wirklich abmelden?</system:String>
 	<system:String x:Key="Subscription.Switched">Zu {0} gewechselt</system:String>
 	<system:String x:Key="Subscription.Switched.Desc1">
-		hre aktuelle Sitzung wurde von Ihrer anderen Sitzung {0} zur Rückkehr aufgefordert. Alle Laufwerke werden wieder verbunden. Bitte speichern Sie die Datei (en) oder schließen Sie die Anwendung (en).
+		Ihre aktuelle Sitzung wurde von Ihrer anderen Sitzung {0} zur Rückkehr aufgefordert. Alle Laufwerke werden wieder verbunden. Bitte speichern Sie die Datei (en) oder schließen Sie die Anwendung (en).
 	</system:String>
 	<system:String x:Key="Subscription.Switched.Desc2">Es wird nach {0} angewendet. Drücken Sie die OK-Taste, um sofort zu arbeiten.</system:String>
 

--- a/StringDictionary.de.xaml
+++ b/StringDictionary.de.xaml
@@ -239,8 +239,8 @@
 	<system:String x:Key="Subscription.Switched.Desc2">Es wird nach {0} angewendet. Drücken Sie die OK-Taste, um sofort zu arbeiten.</system:String>
 
 	<!--  from version 1.8.0  -->
-	<system:String x:Key="Words.Public">Öffentlichkeit</system:String>
-	<system:String x:Key="Words.Private">Privatgelände</system:String>
+	<system:String x:Key="Words.Public">Öffentlich</system:String>
+	<system:String x:Key="Words.Private">Privat</system:String>
 	<system:String x:Key="Words.Site">Seite</system:String>
 
 	<!--  from version 1.9.0  -->


### PR DESCRIPTION
After checking the file and also looking at Issues I have noticed the v1.8.0 wasn't properly translated from the app and I have also noticed that on the v1.7.0 lines there was a tiny spelling error instead of "Ihre" it said "hre"